### PR TITLE
Solve the problem caused by Chrome `autoplay` restriction

### DIFF
--- a/pc.html
+++ b/pc.html
@@ -646,7 +646,7 @@
     <!--begin video-->
     <div id="wrap">
         <div id="video-wrap1" class="video-wrap">
-            <video id="begin1" class="begin" width="1440" height="650" autoplay="autoplay">
+            <video id="begin1" class="begin" width="1440" height="650" autoplay="autoplay" muted="muted">
                 <source src="./video/begin1.mp4" type="video/mp4" />
                 <source src="./video/begin1.ogv" type="video/ogv" />
                 <source src="./video/begin1.webm" type="video/webm" />
@@ -656,7 +656,7 @@
             </video>
         </div>
         <div id="video-wrap2" class="video-wrap">
-            <video id="begin2" class="begin" width="1440" height="650">
+            <video id="begin2" class="begin" width="1440" height="650" muted="muted">
                 <source src="./video/begin2.mp4" type="video/mp4" />
                 <source src="./video/begin2.ogv" type="video/ogv" />
                 <source src="./video/begin2.webm" type="video/webm" />


### PR DESCRIPTION
An official article about the restriction can be viewed [here](https://developers.google.com/web/updates/2017/09/autoplay-policy-changes) . Chrome of some certain versions would stop `<video>`'s with the attribute `autoplay` from being played automatically, but muted videos are excepted from the regulation. Since your videos itself don't include any audio, so it's the easiest way to solve the problem.